### PR TITLE
fix: use correct version filter for react

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "typescript": "^4.3.2"
   },
   "peerDependencies": {
-    "react": "^16.13.1-^17.0.0"
+    "react": "^16.13.1 || ^17.0.0"
   }
 }


### PR DESCRIPTION
#### Hot Fix
The version filter for react is incorrectly formatted. When trying to install `@adamdickinson/react-service` you get the following error:

```
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "^16.13.1-^17.0.0": Tags may not have any characters that encodeURIComponent encodes.
```

