### PR TITLE
feat: enable strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ As a contrived example, let's say we want to make a random number service.
 
 ```ts
 // 1. We define the service
-const [NumberProvider, useNumber] = createService(({ max: number }) => {
+const [RandomProvider, useRandom] = createService(({ max }: { max: number }) => {
   const [number, setNumber] = useState<number>()
   return {
     update: () => setNumber(Math.floor(Math.random() * max)),
@@ -64,23 +64,25 @@ const [NumberProvider, useNumber] = createService(({ max: number }) => {
   }
 })
 
-// 2. We use the service with the `useNumber` hook in some components
+// 2. We use the service with the `useRandom` hook in some components
 const Displayer = () => {
-  const { number } = useNumber()
-  return <p>The number is {number}</p>
+  const random = useRandom()
+  if (!random) return null
+  return <p>The number is {random.number}</p>
 }
 
 const Changer = () => {
-  const { update } = useNumber()
-  return <button onClick={update}>Randomize!</button>
+  const random = useRandom()
+  if (!random) return null
+  return <button onClick={random.update}>Randomize!</button>
 }
 
-// 3. We expose the service to those components that use it by rendering a parent `NumberProvider` component
+// 3. We expose the service to those components that use it by rendering a parent `RandomProvider` component
 ReactDOM.render(
-  <NumberProvider max={100}>
+  <RandomProvider max={100}>
     <Displayer />
     <Changer />
-  </NumberProvider>,
+  </RandomProvider>,
   document.getElementById('root')
 )
 ```
@@ -111,7 +113,7 @@ interface AuthAPI {
 }
 
 // Define our API as a hook so we can leverage React functionality
-const useAuthAPI = ({ serverUrl: string }) => {
+const useAuthAPI = ({ serverUrl }: { serverUrl: string }) => {
   const [user, setUser] = useState<User>()
 
   const onChangeUser = (newUser?: User) => {
@@ -173,14 +175,14 @@ import { useAuth } from './services/auth'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 
 export default () => {
-  const { user } = useAuth()
+  const auth = useAuth()
   return (
     <Router>
       <Switch>
         // Unauthed routes
-        {!user && <Route path="/" component={LogIn} />}
+        {!auth?.user && <Route path="/" component={LogIn} />}
         // Authed routes
-        {!!user && <Route path="/" component={Welcome} />}
+        {!!auth?.user && <Route path="/" component={Welcome} />}
       </Switch>
     </Router>
   )
@@ -193,14 +195,14 @@ import { useAuth } from './services/auth'
 import { useState } from 'react'
 
 export default () => {
-  const { logIn } = useAuth()
+  const auth = useAuth()
   const [loggingIn, setLoggingIn] = useState(false)
   const [error, setError] = useState('')
 
-  const onLogIn = async () => {
+  const login = async () => {
     setLoggingIn(true)
     try {
-      await logIn('me', 'my-pass')
+      await auth.logIn('me', 'my-pass')
     } catch (error) {
       setError(error?.message || error)
       setLoggingIn(false)
@@ -210,7 +212,7 @@ export default () => {
   return (
     <>
       {error && <p>{error}</p>}
-      <button onClick={onLogIn}>Log In</button>
+      <button onClick={login}>Log In</button>
     </>
   )
 }
@@ -221,8 +223,8 @@ export default () => {
 import { useAuth } from './services/auth'
 
 export default () => {
-  const { user } = useAuth()
-  return `Welcome ${user?.firstName}!`
+  const auth = useAuth()
+  return `Welcome ${auth?.user?.firstName}!`
 }
 ```
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ export default {
     sourcemap: true,
   },
   plugins: [
-    typescript({ target: 'es5' }),
+    typescript({ target: 'es5', tsconfig: 'tsconfig.main.json' }),
     cleanup({ comments: 'none' }),
     terser(),
   ],

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -16,7 +16,7 @@ describe('createService', () => {
 
     const logIn = useCallback(
       async (username: string, _password: string) => {
-        setUser({ name: 'you' })
+        setUser({ name: username })
         return user
       },
       [setUser]
@@ -43,7 +43,7 @@ describe('createService', () => {
       <div>
         <h1 data-testid="welcome">Hi there{user ? ` ${user.name}` : ''}!</h1>
         <button
-          onClick={user ? logOut : () => logIn('', '')}
+          onClick={user ? logOut : () => logIn('joe', '')}
           data-testid="logInOut"
         >
           Log {user ? 'out' : 'in'}
@@ -59,7 +59,7 @@ describe('createService', () => {
       <div>
         <h1 data-testid="welcome">Hi there{user ? ` ${user.name}` : ''}!</h1>
         <button
-          onClick={user ? logOut : () => logIn('', '')}
+          onClick={user ? logOut : () => logIn('joe', '')}
           data-testid="logInOut"
         >
           Log {user ? 'out' : 'in'}
@@ -82,7 +82,7 @@ describe('createService', () => {
     expect(button).toHaveTextContent('Log in')
     fireEvent.click(button)
 
-    expect(name).toHaveTextContent('Hi there you!')
+    expect(name).toHaveTextContent('Hi there joe!')
     expect(button).toHaveTextContent('Log out')
     fireEvent.click(button)
 
@@ -125,7 +125,7 @@ describe('createService', () => {
     expect(button).toHaveTextContent('Log in')
     fireEvent.click(button)
 
-    expect(name).toHaveTextContent('Hi there you!')
+    expect(name).toHaveTextContent('Hi there joe!')
     expect(button).toHaveTextContent('Log out')
     fireEvent.click(button)
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,12 +8,12 @@ export interface ServiceProps<A> {
 }
 
 type ServiceComponent<A, P> = React.FC<P & ServiceProps<A>>
-type ServiceHook<A> = () => A
+type ServiceHook<A> = () => A | undefined
 
 export const createService = <A, P = {}>(
   useApi: (props: P) => A
-): [ServiceComponent<A, P>, ServiceHook<A>, React.Context<A>] => {
-  const context = createContext<A>(undefined)
+): [ServiceComponent<A, P>, ServiceHook<A>, React.Context<A | undefined>] => {
+  const context = createContext<A | undefined>(undefined)
 
   const ServiceComponent = createServiceComponent<A, P>(context, useApi)
 
@@ -22,8 +22,8 @@ export const createService = <A, P = {}>(
 }
 
 const createServiceComponent = <A, P = {}>(
-  context: React.Context<A>,
-  useApi: (props: Omit<P, 'children' | 'fallback'>) => A
+  context: React.Context<A | undefined>,
+  useApi: (props: P) => A
 ): ServiceComponent<A, P> => {
   const { Provider } = context
   const Service: ServiceComponent<A, P> = ({
@@ -31,7 +31,7 @@ const createServiceComponent = <A, P = {}>(
     fallback: Fallback,
     ...props
   }) => {
-    const api = useApi(props)
+    const api = useApi(props as unknown as P)
     if (api !== undefined) {
       const renderChildren =
         typeof children === 'function' && (children as ServiceRenderFunction<A>)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,9 @@
     "moduleResolution": "node",
     "declaration": true,
     "jsx": "react",
+    "strict": true,
     "target": "es2018",
     "noEmit": true,
     "outDir": "./dist/"
-  },
-  "files": ["src/index.tsx"]
+  }
 }

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["src/index.tsx"]
+}


### PR DESCRIPTION
### Enable `strict` mode in `tsconfig`
This PR enables [`strict`](https://www.typescriptlang.org/tsconfig#strict) in `tsconfig` in order to catch extra type issues.

As a result of this, a service hook's result type now accurately reflects that fact that it can return `undefined`. This may be a breaking change for consumers with `strict` mode enabled in their `tsconfig` and they will need to check the result correctly.

Fixes #16, #17